### PR TITLE
Fix additional-files failing during copyDirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.classpath
 /.project
 /work
+*~


### PR DESCRIPTION
Bug:
Backup additional files does not check for copy errors
in copyDirectory such as broken symlink, no read permission

Fix:
- Symlinks are no longer followed nor copied by additional-files-backup
- Only those files that can be read are copied