### PR TITLE
Fix copyDirectory failing with exception

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/utils/ExistsAndReadableFileFilter.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/utils/ExistsAndReadableFileFilter.java
@@ -1,0 +1,30 @@
+package org.jvnet.hudson.plugins.thinbackup.utils;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.Serializable;
+import org.apache.commons.io.filefilter.AbstractFileFilter;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.commons.io.filefilter.IOFileFilter;
+
+public class ExistsAndReadableFileFilter extends AbstractFileFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Wraps the supplied filter to make if safe against broken symlinks and missing read permissions
+     * @param filter The core filter that'll be wrapped inside safety checks
+     * @return The wrapped file filter
+     */
+    public static IOFileFilter wrapperFilter(final IOFileFilter filter) {
+        return FileFilterUtils.asFileFilter(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                File file = new File(dir, name);
+                if (file.exists() && file.canRead()) {
+                    return filter.accept(file);
+                }
+                return false;
+            }
+        });
+    }
+}


### PR DESCRIPTION
- copyDirectory now uses a wrapped filter: wrapper checks for
  existence and readability of file before applying core filter